### PR TITLE
feat(sdk): 支持应用进入前台时清除通知栏

### DIFF
--- a/sdk/android/DooPushSDK/lib/src/main/java/com/doopush/sdk/DooPushManager.kt
+++ b/sdk/android/DooPushSDK/lib/src/main/java/com/doopush/sdk/DooPushManager.kt
@@ -775,15 +775,23 @@ class DooPushManager private constructor() {
     fun disconnectTCP() {
         tcpConnection?.disconnect()
     }
-    
+
     /**
-     * 应用进入前台时调用
+     * 应用进入前台时调用，执行通知清除和角标重置
+     * @param context Android 上下文，推荐使用 Application 上下文
      */
-    fun applicationDidBecomeActive() {
+    fun applicationDidBecomeActive(context: Context) {
         tcpConnection?.applicationDidBecomeActive()
         Log.d(TAG, "应用进入前台")
+        // 清除通知栏消息
+        // TODO 如果应用没有初始化 SDK 也可以清除通知？
+        DooPushNotificationHandler.clearNotifications(context)
+        // 清除角标（仅在SDK已初始化时执行）
+        if (checkInitialized()) {
+            clearBadge()
+        }
     }
-    
+
     /**
      * 应用进入后台时调用
      */

--- a/sdk/android/DooPushSDK/lib/src/main/java/com/doopush/sdk/DooPushNotificationHandler.kt
+++ b/sdk/android/DooPushSDK/lib/src/main/java/com/doopush/sdk/DooPushNotificationHandler.kt
@@ -2,8 +2,8 @@ package com.doopush.sdk
 
 import android.content.Context
 import android.content.Intent
-import android.os.Bundle
 import android.util.Log
+import android.app.NotificationManager
 import com.doopush.sdk.models.PushMessage
 import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
@@ -240,6 +240,39 @@ object DooPushNotificationHandler {
             Log.d(TAG, "已添加推送点击数据到Intent")
         } catch (e: Exception) {
             Log.e(TAG, "添加推送点击数据失败", e)
+        }
+    }
+
+    /**
+     * 清除所有通知栏消息
+     * @param context Android 上下文
+     * @return 是否清除成功
+     */
+    fun clearNotifications(context: Context): Boolean {
+        try {
+            val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            // 通用通知清除
+            notificationManager.cancelAll()
+
+            // 厂商特定通知清除（可扩展）
+            // TODO 考虑用于通知或者触发特点厂商自己的清除逻辑？
+            when (DooPushDeviceVendor.getDeviceVendorInfo().preferredService) {
+                DooPushDeviceVendor.PushService.MIPUSH -> {
+                    // XiaomiService(context).clearNotifications()
+                }
+                DooPushDeviceVendor.PushService.OPPO -> {
+                    // OppoService(context).clearNotifications()
+                }
+                else -> {
+                    Log.d(TAG, "执行通用通知清除")
+                }
+            }
+
+            Log.d(TAG, "通知栏消息清除成功")
+            return true
+        } catch (e: Exception) {
+            Log.e(TAG, "通知栏消息清除失败", e)
+            return false
         }
     }
     

--- a/sdk/android/DooPushSDKExample/app/src/main/java/com/doopush/DooPushSDKExample/AppLifecycleHandler.kt
+++ b/sdk/android/DooPushSDKExample/app/src/main/java/com/doopush/DooPushSDKExample/AppLifecycleHandler.kt
@@ -42,7 +42,7 @@ class AppLifecycleHandler : Application.ActivityLifecycleCallbacks {
         
         // 第一个Activity恢复时，通知SDK应用进入前台
         if (activityCount == 1) {
-            DooPushManager.getInstance().applicationDidBecomeActive()
+            DooPushManager.getInstance().applicationDidBecomeActive(activity.applicationContext)
         }
     }
     


### PR DESCRIPTION
- 修改 applicationDidBecomeActive，添加 Context 参数，支持未初始化 SDK 时清除通知。
- 移除对 applicationContext 的依赖，防止“Context 为空”错误。
- 原因：通过传入 Context 解耦 SDK 初始化依赖，提升通知清除的灵活性和可靠性。