### PR TITLE
fix: 修复 OPPO 推送注册静默超时（补全 HeyTap MCS manifest 声明）

### DIFF
--- a/docs/sdk/android-integration.md
+++ b/docs/sdk/android-integration.md
@@ -177,6 +177,10 @@ dependencies {
 <uses-permission android:name="com.vivo.notification.permission.BADGE_ICON" />
 <uses-permission android:name="com.meizu.flyme.permission.PUSH" />
 
+<!-- OPPO/HeyTap (ColorOS) 推送：MCS 回传 RegisterId/消息所需，oppo-push 的 aar 不自带 -->
+<uses-permission android:name="com.coloros.mcs.permission.RECIEVE_MCS_MESSAGE" />
+<uses-permission android:name="com.heytap.mcs.permission.RECIEVE_MCS_MESSAGE" />
+
 <!-- 自启动权限（部分厂商需要） -->
 <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 ```
@@ -263,7 +267,31 @@ plugins {
 }
 ```
 
-**说明**：OPPO推送直接通过 Gradle 依赖集成，无需额外配置。
+4. 在 `AndroidManifest.xml` 的 `<application>` 内声明 HeyTap MCS 回调 service（连同上面权限配置里的两个 `RECIEVE_MCS_MESSAGE` 权限）：
+
+```xml
+<service
+    android:name="com.heytap.msp.push.service.CompatibleDataMessageCallbackService"
+    android:permission="com.coloros.mcs.permission.SEND_MCS_MESSAGE"
+    android:exported="true">
+    <intent-filter>
+        <action android:name="com.coloros.mcs.action.RECEIVE_MCS_MESSAGE" />
+    </intent-filter>
+</service>
+<service
+    android:name="com.heytap.msp.push.service.DataMessageCallbackService"
+    android:permission="com.heytap.mcs.permission.SEND_PUSH_MESSAGE"
+    android:exported="true">
+    <intent-filter>
+        <action android:name="com.heytap.mcs.action.RECEIVE_MCS_MESSAGE" />
+        <action android:name="com.heytap.msp.push.RECEIVE_MCS_MESSAGE" />
+    </intent-filter>
+</service>
+```
+
+> **说明**：OPPO 推送依赖 `com.umeng.umsdk:oppo-push`，但该 aar 自带的 manifest 为空——上面两个 `RECIEVE_MCS_MESSAGE` 权限和两个回调 service **必须手动声明**（其它厂商 aar 已自带，无需手动加）。缺失时系统推送服务无法把 RegisterId 回传给应用，`register()` 会静默超时、拿不到 token。
+>
+> 使用 Expo config plugin（`doopush-react-native-sdk`）的项目无需手动添加：启用 `oppo` vendor 后，这些权限与 service 会在 `prebuild` 时自动注入。
 
 #### VIVO推送配置
 

--- a/docs/sdk/react-native-integration.md
+++ b/docs/sdk/react-native-integration.md
@@ -266,6 +266,7 @@ const { deviceId } = await DooPush.registerWithToken(token, 'fcm');
 
 - **Android `expo prebuild` 报 `manifestPlaceholders` 找不到字段** —— 检查 `app.json` 里 OEM 凭证是否齐全（schema 校验会要求 servicesFile 或对应内联字段）。
 - **HMS / Honor 真机注册失败** —— 确认 `agconnect-services.json` / `mcs-services.json` 真机可读、`app.json` 的 `bundleIdentifier` 与 services file 中的 `package_name` 一致。
+- **OPPO 真机注册卡住 / 超时拿不到 token** —— 启用 `oppo` vendor 时 plugin 会在 `prebuild` 自动注入 HeyTap MCS 的权限与回调 service（`oppo-push` aar 不自带）。若仍失败，先重新 `expo prebuild` 确认合并后的 `AndroidManifest.xml` 含 `com.heytap.msp.push.service.DataMessageCallbackService`，再核对 OPPO 开放平台登记的包名与该应用一致。
 - **`Unable to resolve "doopush-react-native-sdk"`** —— monorepo 本地开发用 `file:` 依赖时加 `--install-links`，避免 npm 默认软链导致 Metro 解析失败。
 
 ## 📦 版本与发布

--- a/sdk/android/DooPushSDK/lib/src/main/java/com/doopush/sdk/DooPushManager.kt
+++ b/sdk/android/DooPushSDK/lib/src/main/java/com/doopush/sdk/DooPushManager.kt
@@ -368,7 +368,9 @@ class DooPushManager private constructor() {
         Log.d(TAG, "开始注册推送通知")
         isRegistering.set(true)
         
-        // 超时保护，避免底层SDK无回调导致卡住
+        // 超时保护，避免底层SDK无回调导致卡住。
+        // 必须大于各厂商取 token 的内部超时（OPPO 轮询 30s，见 OppoService.startPollingForRegisterId），
+        // 否则厂商真实的失败原因（如 OPPO 包名/appKey 不匹配）会被这个通用超时覆盖成“网络请求超时”。
         mainHandler.postDelayed({
             if (isRegistering.get()) {
                 isRegistering.set(false)
@@ -376,7 +378,7 @@ class DooPushManager private constructor() {
                 Log.e(TAG, error.getFullDescription())
                 callback?.onError(error) ?: this.callback?.onRegisterError(error)
             }
-        }, 15000L)
+        }, 35000L)
         
         try {
             // 根据设备厂商选择最优推送服务

--- a/sdk/android/DooPushSDK/lib/src/main/java/com/doopush/sdk/OppoService.kt
+++ b/sdk/android/DooPushSDK/lib/src/main/java/com/doopush/sdk/OppoService.kt
@@ -246,24 +246,27 @@ class OppoService(private val context: Context) {
      * @param callback token获取回调
      */
     fun getToken(callback: TokenCallback) {
+        // 必须先设回调：晚于任何可能同步触发 onRegister 的 SDK 调用就会丢掉初始化期间的注册结果。
+        this.tokenCallback = callback
+
+        val cachedToken = getRegId()
+        if (!cachedToken.isNullOrEmpty()) {
+            Log.d(TAG, "使用缓存的OPPO推送token: ${cachedToken.take(12)}...")
+            handleRegisterCallback(0, cachedToken)
+            return
+        }
+
         if (cachedAppKey != null && cachedAppSecret != null) {
-            // 尝试获取已缓存的token
-            val cachedToken = getRegId()
-            if (!cachedToken.isNullOrEmpty()) {
-                Log.d(TAG, "使用缓存的OPPO推送token: ${cachedToken.take(12)}...")
-                callback.onSuccess(cachedToken)
-            } else {
-                // 如果没有缓存token，重新初始化以触发注册回调
-                this.tokenCallback = callback // 缓存回调
-                initialize(cachedAppKey!!, cachedAppSecret!!)
+            // initialize() 失败时不会启动轮询、也不回调，必须主动报错并清空回调，
+            // 否则注册会悬挂到 DooPushManager 的 35s 通用超时，盖住真实失败原因。
+            if (!initialize(cachedAppKey!!, cachedAppSecret!!)) {
+                this.tokenCallback = null
+                callback.onError(DooPushError.oppoInitFailed("OPPO推送初始化失败"))
             }
         } else {
-            // 尝试自动初始化
             val success = autoInitialize()
-            if (success && cachedAppKey != null && cachedAppSecret != null) {
-                // 自动初始化成功后，再次尝试获取token
-                getToken(callback)
-            } else {
+            if (!success) {
+                this.tokenCallback = null
                 callback.onError(DooPushError.oppoConfigInvalid("OPPO推送未正确配置或初始化"))
             }
         }

--- a/sdk/react-native/DooPushSDK/android/src/main/java/com/doopush/reactnative/DooPushReactNativeSDKModule.kt
+++ b/sdk/react-native/DooPushSDK/android/src/main/java/com/doopush/reactnative/DooPushReactNativeSDKModule.kt
@@ -80,7 +80,7 @@ class DooPushReactNativeSDKModule : Module(), DooPushCallback {
                         ))
                     }
                     override fun onError(error: DooPushError) {
-                        promise.reject("E_REGISTER", error.message ?: "register failed", null)
+                        promise.reject("E_REGISTER", error.getFullDescription(), error)
                     }
                 }
             )
@@ -99,7 +99,7 @@ class DooPushReactNativeSDKModule : Module(), DooPushCallback {
                         promise.resolve(mapOf("deviceId" to result.deviceId))
                     }
                     override fun onError(error: DooPushError) {
-                        promise.reject("E_REGISTER", error.message ?: "register failed", null)
+                        promise.reject("E_REGISTER", error.getFullDescription(), error)
                     }
                 }
             )
@@ -222,7 +222,7 @@ class DooPushReactNativeSDKModule : Module(), DooPushCallback {
     override fun onRegisterError(error: DooPushError) {
         sendEvent("onRegisterError", mapOf(
             "code" to "E_REGISTER",
-            "message" to (error.message ?: "register failed")
+            "message" to error.getFullDescription()
         ))
     }
 

--- a/sdk/react-native/DooPushSDK/plugin/src/android/withAndroid.ts
+++ b/sdk/react-native/DooPushSDK/plugin/src/android/withAndroid.ts
@@ -5,6 +5,7 @@ import { withDooPushSettingsGradle } from './withSettingsGradle';
 import { withDooPushAppBuildGradle } from './withAppBuildGradle';
 import { withDooPushGradleProperties } from './withGradleProperties';
 import { withDooPushGoogleServices } from './withGoogleServices';
+import { withDooPushOppoManifest } from './withOppoManifest';
 
 export const withAndroid: ConfigPlugin<PluginConfig> = (config, validated) => {
   config = withDooPushSettingsGradle(config, validated);
@@ -12,5 +13,6 @@ export const withAndroid: ConfigPlugin<PluginConfig> = (config, validated) => {
   config = withDooPushRootBuildGradle(config, validated);
   config = withDooPushAppBuildGradle(config, validated);
   config = withDooPushGoogleServices(config, validated);
+  config = withDooPushOppoManifest(config, validated);
   return config;
 };

--- a/sdk/react-native/DooPushSDK/plugin/src/android/withOppoManifest.ts
+++ b/sdk/react-native/DooPushSDK/plugin/src/android/withOppoManifest.ts
@@ -1,0 +1,63 @@
+import { AndroidConfig, ConfigPlugin, withAndroidManifest } from '@expo/config-plugins';
+import type { PluginConfig } from '../schema';
+
+/**
+ * HeyTap MCS（OPPO/ColorOS 推送）要求在 AndroidManifest 声明的权限与回调 service。
+ *
+ * umeng `oppo-push` 的 aar 自带 manifest 为空（只声明 package），不会贡献这些节点；
+ * 其余 vendor 的 aar 自带完整 manifest，所以只有 OPPO 需要 plugin 主动补。缺这些节点时，
+ * 系统推送服务收到注册后无处回传 RegisterId，DooPush.register() 会静默超时、拿不到 token。
+ */
+const MCS_PERMISSIONS = [
+  'com.coloros.mcs.permission.RECIEVE_MCS_MESSAGE',
+  'com.heytap.mcs.permission.RECIEVE_MCS_MESSAGE',
+];
+
+const MCS_SERVICES: { name: string; permission: string; actions: string[] }[] = [
+  {
+    name: 'com.heytap.msp.push.service.CompatibleDataMessageCallbackService',
+    permission: 'com.coloros.mcs.permission.SEND_MCS_MESSAGE',
+    actions: ['com.coloros.mcs.action.RECEIVE_MCS_MESSAGE'],
+  },
+  {
+    name: 'com.heytap.msp.push.service.DataMessageCallbackService',
+    permission: 'com.heytap.mcs.permission.SEND_PUSH_MESSAGE',
+    actions: [
+      'com.heytap.mcs.action.RECEIVE_MCS_MESSAGE',
+      'com.heytap.msp.push.RECEIVE_MCS_MESSAGE',
+    ],
+  },
+];
+
+export const withDooPushOppoManifest: ConfigPlugin<PluginConfig> = (config, validated) => {
+  // service 类来自 oppo-push 依赖，仅在启用 OPPO vendor 时注入。
+  if (!validated.android.vendors.oppo) {
+    return config;
+  }
+
+  return withAndroidManifest(config, (cfg) => {
+    AndroidConfig.Permissions.ensurePermissions(cfg.modResults, MCS_PERMISSIONS);
+
+    const application = AndroidConfig.Manifest.getMainApplication(cfg.modResults);
+    if (!application) return cfg;
+    application.service = application.service ?? [];
+    for (const svc of MCS_SERVICES) {
+      const exists = application.service.some(
+        (s) => s.$?.['android:name'] === svc.name
+      );
+      if (exists) continue;
+      application.service.push({
+        $: {
+          'android:name': svc.name,
+          'android:permission': svc.permission,
+          'android:exported': 'true',
+        },
+        'intent-filter': [
+          { action: svc.actions.map((a) => ({ $: { 'android:name': a } })) },
+        ],
+      });
+    }
+
+    return cfg;
+  });
+};


### PR DESCRIPTION
## 背景

在 OPPO / ColorOS 真机上调用 `DooPush.register()` 会**静默超时、拿不到 token**，且 JS 侧只能看到通用的「网络请求超时」，无法定位真正原因。

## 根因

**OPPO 的 HeyTap MCS 回调 service 在合并后的 `AndroidManifest.xml` 里没有任何地方声明。**

各厂商的推送组件来源不同（下表均实测自对应 aar 内的 `AndroidManifest.xml`）：

| aar 来源 | manifest 里自带的组件 |
|---|---|
| `com.umeng.umsdk:xiaomi-push` | `XMPushService` / `XMJobService` / `PushMessageHandler` / `MessageHandleService` 四个 service + `PingReceiver` + Activity + `MIPUSH_RECEIVE` 权限 |
| `com.umeng.umsdk:vivo-push` | `CommandClientService` |
| `com.doopush:android-sdk` | FCM `DooPushFirebaseMessagingService`、vivo `DooPushVivoMessageReceiver`，以及 mi / vivo / honor 的 appId·appKey·developerId 占位 meta-data |
| `com.umeng.umsdk:oppo-push` | **manifest 仅 439B**：只有 `package` / `uses-sdk` / 一个 `sdkVersion` meta-data，**无 service、无 receiver、无权限**（service 类只在 `classes.jar` 里，manifest 不声明） |

可见：

- 小米、vivo 的推送组件来自**各自的厂商 aar**；`com.doopush:android-sdk` 真正 baked 的组件只有 FCM service 与 vivo receiver；
- OPPO 渠道依赖的 `oppo-push` aar **几乎是空 manifest**，`com.doopush:android-sdk` 又**没替 OPPO 补任何节点**，config plugin 之前也只注入 `manifestPlaceholders`、不声明节点。

三处叠加 → 两个 HeyTap MCS 回调 service（`CompatibleDataMessageCallbackService` / `DataMessageCallbackService`）在合并后的 manifest 里**根本不存在** → 系统收到注册后无处投递 RegisterId → `register()` 静默超时。

**真实错误还被通用超时掩盖：**

- `DooPushManager` 的注册看门狗 15s 触发，**短于** `OppoService` 的 30s RegisterId 轮询，厂商真实失败码来不及上报就被覆盖成「网络请求超时」；
- `OppoService.getToken` 先 `autoInitialize` 再设回调，初始化期间到达的注册回调因 `tokenCallback` 为空被静默丢弃。

## 改动

**`rn-plugin`（根因修复）**

- 新增 `withDooPushOppoManifest`：启用 `oppo` vendor 时，在 `prebuild` 注入两个 `RECIEVE_MCS_MESSAGE` 权限与两个回调 service（`CompatibleDataMessageCallbackService` / `DataMessageCallbackService`）。注入幂等，已存在则跳过。
- 更正文档：原先写「OPPO 推送无需额外配置」有误，补充手动声明步骤与故障排查。

**`android-sdk`（错误可观测性）**

- 注册看门狗 15s → 35s，使其大于 OPPO 的 30s 轮询，避免掩盖厂商真实错误。
- `OppoService.getToken` 先缓存回调再触发初始化，去掉递归重入，确保初始化期间的注册结果不被丢弃。
- RN bridge 注册失败改用 `DooPushError.getFullDescription()`（带数值码与 details）上报，JS 可区分「网络超时」与「OPPO 包名/appKey 不匹配」等真实原因。

## 兼容性

- 仅在启用 `oppo` vendor 时注入 manifest 节点，不影响其它厂商；
- 注入幂等（节点已存在则跳过），重复 `prebuild` 安全；
- 看门狗超时为全局，OPPO 失败场景下报错时延从 15s 变为最多 35s（换取不再掩盖真实错误）。

## 测试

- [x] config plugin TypeScript 编译通过；
- [x] `prebuild` 后合并的 `AndroidManifest.xml` 含 `com.heytap.msp.push.service.DataMessageCallbackService` 及两个 `RECIEVE_MCS_MESSAGE` 权限；
- [ ] 建议 reviewer 在 OPPO 真机回归：`register()` 能正常拿到 RegisterId / token。
