### PR TITLE
fix(rn-sdk-android): 修复 Expo 通知图标冲突并兼容 Expo 54 荣耀配置

### DIFF
--- a/sdk/react-native/DooPushSDK/plugin/src/__tests__/android.test.ts
+++ b/sdk/react-native/DooPushSDK/plugin/src/__tests__/android.test.ts
@@ -1,4 +1,5 @@
 import { withAndroid } from '../android/withAndroid';
+import { preferHostNotificationIcon } from '../android/withNotificationManifest';
 import { ExpoConfig } from '@expo/config-types';
 
 const baseConfig: ExpoConfig = {
@@ -24,6 +25,7 @@ describe('withAndroid', () => {
     expect(typeof result.mods.android.gradleProperties).toBe('function');
     expect(typeof result.mods.android.projectBuildGradle).toBe('function');
     expect(typeof result.mods.android.appBuildGradle).toBe('function');
+    expect(typeof result.mods.android.manifest).toBe('function');
     expect(typeof result.mods.android.dangerous).toBe('function');
   });
 
@@ -37,6 +39,69 @@ describe('withAndroid', () => {
     // but dangerous (file copy) is skipped because no FCM file is provided.
     expect(result.mods?.android?.gradleProperties).toBeDefined();
     expect(result.mods?.android?.projectBuildGradle).toBeDefined();
+    expect(result.mods?.android?.manifest).toBeDefined();
     expect(result.mods?.android?.dangerous).toBeUndefined();
+  });
+});
+
+describe('preferHostNotificationIcon', () => {
+  test('marks an existing host FCM icon as authoritative', () => {
+    const manifest: any = {
+      manifest: {
+        $: { 'xmlns:android': 'http://schemas.android.com/apk/res/android' },
+        application: [
+          {
+            $: { 'android:name': '.MainApplication' },
+            'meta-data': [
+              {
+                $: {
+                  'android:name': 'com.google.firebase.messaging.default_notification_icon',
+                  'android:resource': '@drawable/notification_icon',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    expect(preferHostNotificationIcon(manifest)).toBe(true);
+    expect(manifest.manifest.$['xmlns:tools']).toBe(
+      'http://schemas.android.com/tools'
+    );
+    expect(manifest.manifest.application[0]['meta-data'][0].$['tools:replace']).toBe(
+      'android:resource'
+    );
+  });
+
+  test('creates the Expo host icon metadata when the manifest mod runs first', () => {
+    const manifest: any = {
+      manifest: {
+        $: { 'xmlns:android': 'http://schemas.android.com/apk/res/android' },
+        application: [{ $: { 'android:name': '.MainApplication' } }],
+      },
+    };
+
+    expect(preferHostNotificationIcon(manifest, true)).toBe(true);
+    expect(manifest.manifest.application[0]['meta-data']).toContainEqual({
+      $: {
+        'android:name': 'com.google.firebase.messaging.default_notification_icon',
+        'android:resource': '@drawable/notification_icon',
+        'tools:replace': 'android:resource',
+      },
+    });
+  });
+
+  test('keeps the native SDK fallback when the host does not configure an icon', () => {
+    const manifest: any = {
+      manifest: {
+        $: { 'xmlns:android': 'http://schemas.android.com/apk/res/android' },
+        application: [{ $: { 'android:name': '.MainApplication' } }],
+      },
+    };
+
+    expect(preferHostNotificationIcon(manifest)).toBe(false);
+    expect(manifest.manifest.$['xmlns:tools']).toBeUndefined();
+    expect(manifest.manifest.application[0]['meta-data']).toBeUndefined();
   });
 });

--- a/sdk/react-native/DooPushSDK/plugin/src/android/withAndroid.ts
+++ b/sdk/react-native/DooPushSDK/plugin/src/android/withAndroid.ts
@@ -6,6 +6,7 @@ import { withDooPushAppBuildGradle } from './withAppBuildGradle';
 import { withDooPushGradleProperties } from './withGradleProperties';
 import { withDooPushGoogleServices } from './withGoogleServices';
 import { withDooPushOppoManifest } from './withOppoManifest';
+import { withDooPushNotificationManifest } from './withNotificationManifest';
 
 export const withAndroid: ConfigPlugin<PluginConfig> = (config, validated) => {
   config = withDooPushSettingsGradle(config, validated);
@@ -14,5 +15,6 @@ export const withAndroid: ConfigPlugin<PluginConfig> = (config, validated) => {
   config = withDooPushAppBuildGradle(config, validated);
   config = withDooPushGoogleServices(config, validated);
   config = withDooPushOppoManifest(config, validated);
+  config = withDooPushNotificationManifest(config, validated);
   return config;
 };

--- a/sdk/react-native/DooPushSDK/plugin/src/android/withAppBuildGradle.ts
+++ b/sdk/react-native/DooPushSDK/plugin/src/android/withAppBuildGradle.ts
@@ -3,9 +3,30 @@ import {
   withAppBuildGradle,
 } from '@expo/config-plugins';
 import type { PluginConfig } from '../schema';
+import * as fs from 'fs';
+import * as path from 'path';
 
 function q(value: string | undefined): string {
   return `"${(value ?? '').replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * When the Honor vendor uses file mode (mcsServicesFile) without inline appId/developerId,
+ * read them from the file so the DOOPUSH_HONOR_APP_ID / DOOPUSH_HONOR_DEVELOPER_ID
+ * manifest placeholders are populated. The Honor push SDK requires these meta-data entries
+ * at runtime; empty values → error 3607 "missing AppId".
+ */
+function resolveHonorInline(projectRoot: string, vendor: NonNullable<PluginConfig['android']['vendors']['honor']>): void {
+  if (!vendor.mcsServicesFile || (vendor.appId && vendor.developerId)) return;
+  try {
+    const abs = path.isAbsolute(vendor.mcsServicesFile)
+      ? vendor.mcsServicesFile
+      : path.resolve(projectRoot, vendor.mcsServicesFile);
+    if (!fs.existsSync(abs)) return;
+    const mcs = JSON.parse(fs.readFileSync(abs, 'utf8'));
+    if (!vendor.appId && mcs.app_id) vendor.appId = String(mcs.app_id);
+    if (!vendor.developerId && mcs.developer_id) vendor.developerId = String(mcs.developer_id);
+  } catch { /* file may not exist yet during config evaluation — skip gracefully */ }
 }
 
 function addApplyPlugin(contents: string, pluginId: string): string {
@@ -52,6 +73,13 @@ export const withDooPushAppBuildGradle: ConfigPlugin<PluginConfig> = (config, va
   return withAppBuildGradle(config, (cfg) => {
     let contents = cfg.modResults.contents;
     const v = validated.android.vendors;
+
+    // Honor file mode: if appId/developerId aren't provided inline, resolve them from
+    // mcs-services.json so manifest placeholders are populated at build time.
+    if (v.honor) {
+      const projectRoot = (cfg as any).modRequest?.projectRoot || process.cwd();
+      resolveHonorInline(projectRoot, v.honor);
+    }
 
     // 1. Apply vendor Gradle plugins where required by the upstream SDKs.
     if (v.fcm) contents = addApplyPlugin(contents, 'com.google.gms.google-services');

--- a/sdk/react-native/DooPushSDK/plugin/src/android/withNotificationManifest.ts
+++ b/sdk/react-native/DooPushSDK/plugin/src/android/withNotificationManifest.ts
@@ -1,0 +1,68 @@
+import { AndroidConfig, ConfigPlugin, withAndroidManifest } from '@expo/config-plugins';
+import type { PluginConfig } from '../schema';
+
+const FIREBASE_DEFAULT_NOTIFICATION_ICON =
+  'com.google.firebase.messaging.default_notification_icon';
+type AndroidManifest = Parameters<
+  typeof AndroidConfig.Manifest.getMainApplication
+>[0];
+
+/**
+ * DooPush's native Android SDK provides @drawable/ic_notification as a fallback
+ * for apps that do not configure an FCM notification icon. When the host app
+ * already declares its own icon (for example through expo-notifications), mark
+ * the host value as authoritative so Android's manifest merger can override the
+ * SDK fallback instead of failing on the two different resources.
+ */
+export function preferHostNotificationIcon(
+  manifest: AndroidManifest,
+  ensureExpoNotificationIcon = false
+): boolean {
+  const application = AndroidConfig.Manifest.getMainApplication(manifest);
+  if (!application) {
+    return false;
+  }
+
+  const metadata = application['meta-data'] ?? [];
+  let defaultNotificationIcon = metadata.find(
+    (entry) => entry.$?.['android:name'] === FIREBASE_DEFAULT_NOTIFICATION_ICON
+  );
+
+  // Android manifest mods execute in reverse registration order. When DooPush
+  // is listed after expo-notifications, this mod may run before Expo creates its
+  // metadata. If the host configured notification.icon, create the same entry
+  // Expo will use so the merger override is present regardless of mod order.
+  if (!defaultNotificationIcon && ensureExpoNotificationIcon) {
+    defaultNotificationIcon = {
+      $: {
+        'android:name': FIREBASE_DEFAULT_NOTIFICATION_ICON,
+        'android:resource': '@drawable/notification_icon',
+      },
+    };
+    metadata.push(defaultNotificationIcon);
+    application['meta-data'] = metadata;
+  }
+
+  if (!defaultNotificationIcon?.$?.['android:resource']) {
+    return false;
+  }
+
+  AndroidConfig.Manifest.ensureToolsAvailable(manifest);
+  (defaultNotificationIcon.$ as Record<string, string | undefined>)[
+    'tools:replace'
+  ] = 'android:resource';
+  return true;
+}
+
+export const withDooPushNotificationManifest: ConfigPlugin<PluginConfig> = (
+  config
+) => {
+  const hostConfiguresNotificationIcon = Boolean(config.notification?.icon);
+  return withAndroidManifest(config, (cfg) => {
+    preferHostNotificationIcon(
+      cfg.modResults,
+      hostConfiguresNotificationIcon
+    );
+    return cfg;
+  });
+};

--- a/sdk/react-native/DooPushSDK/plugin/src/android/withRootBuildGradle.ts
+++ b/sdk/react-native/DooPushSDK/plugin/src/android/withRootBuildGradle.ts
@@ -3,6 +3,34 @@ import {
   withProjectBuildGradle,
 } from '@expo/config-plugins';
 import type { PluginConfig } from '../schema';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Honor's asplugin requires an explicit AGP classpath version in root build.gradle.
+ * Expo SDK ≥54 declares AGP without a version (version catalog manages it), so pin
+ * the same version that the RN version catalog resolves to.
+ */
+function pinAgpClasspathVersion(contents: string, projectRoot: string): string {
+  if (/com\.android\.tools\.build:gradle:(?!['"])/g.test(contents)) {
+    // Already has version — idempotent.
+    return contents;
+  }
+  let agp: string | null = null;
+  try {
+    const rnPkg = require.resolve('react-native/package.json', { paths: [projectRoot] });
+    const toml = fs.readFileSync(
+      path.join(path.dirname(rnPkg), 'gradle', 'libs.versions.toml'),
+      'utf8'
+    );
+    agp = toml.match(/^\s*agp\s*=\s*"([^"]+)"/m)?.[1] ?? null;
+  } catch { /* not found — skip */ }
+  if (!agp) return contents;
+  return contents.replace(
+    /com\.android\.tools\.build:gradle(?!:)/g,
+    `com.android.tools.build:gradle:${agp}`
+  );
+}
 
 /**
  * Adds Maven repositories and vendor Gradle plugin classpaths to root build.gradle.
@@ -78,6 +106,9 @@ export const withDooPushRootBuildGradle: ConfigPlugin<PluginConfig> = (config, v
       addAllProjectsRepo(honorRepo, 'developer.hihonor.com/repo');
       addBuildscriptRepo(honorRepo, 'developer.hihonor.com/repo');
       addClasspath("'com.hihonor.mcs:asplugin:2.0.1.300'");
+      // Honor's asplugin scans root build.gradle text for an explicit AGP version;
+      // Expo SDK ≥54 omits the version (managed by the version catalog). Pin it.
+      contents = pinAgpClasspathVersion(contents, cfg.modRequest.projectRoot);
     }
 
     // mavenLocal for development.


### PR DESCRIPTION
## 背景

DooPush React Native config plugin 在 Expo Android 项目中有两类兼容问题：

1. 宿主应用通过 `expo-notifications` 配置通知图标时，DooPush Android SDK 自带的 FCM 默认图标会与宿主图标产生 Manifest 合并冲突；
2. Expo SDK 54 项目启用 Honor Push 时，Honor 配置文件中的 `app_id` / `developer_id` 没有写入 Manifest placeholders，同时 Honor Gradle plugin 无法识别 Expo 54 通过 version catalog 管理、未显式声明版本号的 AGP classpath。

## 根因

### 通知图标冲突

DooPush Android SDK 和宿主应用都会声明：

```xml
<meta-data android:name="com.google.firebase.messaging.default_notification_icon" />
```

两边的 `android:resource` 不同时，Android Manifest merger 无法判断使用哪个值。并且 Expo config mods 按注册顺序的逆序执行，DooPush manifest mod 可能早于 `expo-notifications`，此时宿主图标 metadata 尚未生成，单纯修改已有节点无法覆盖所有顺序。

### Honor + Expo 54

- `mcsServicesFile` 模式只复制了 `mcs-services.json`，没有将其中的 `app_id` / `developer_id` 注入 `DOOPUSH_HONOR_APP_ID` / `DOOPUSH_HONOR_DEVELOPER_ID`，Honor SDK 运行时会因 Manifest AppId 缺失而注册失败；
- Expo SDK 54 的根级 `build.gradle` 使用无版本的 `com.android.tools.build:gradle` classpath，并由 React Native version catalog 管理实际版本；Honor `asplugin` 会扫描 classpath 文本，要求存在显式 AGP 版本。

## 改动

### 通知图标

- 新增 `withDooPushNotificationManifest`；
- 当宿主已声明 FCM 默认通知图标时，为该 metadata 添加：

  ```xml
  tools:replace="android:resource"
  ```

- 当 DooPush mod 早于 `expo-notifications` 执行、且宿主配置了 `notification.icon` 时，提前创建 Expo 使用的 `@drawable/notification_icon` metadata，确保不同 mod 顺序下都能正确合并；
- 未配置宿主通知图标时保持 DooPush SDK 自带的 fallback，不额外修改 Manifest；
- 增加已有图标、逆序执行和无宿主图标三个单元测试。

### Honor + Expo 54

- `mcsServicesFile` 模式下读取 `app_id` / `developer_id`，用于填充 Honor Manifest placeholders；
- 从当前项目解析 `react-native/package.json`，读取 `react-native/gradle/libs.versions.toml` 中的 AGP 版本；
- 将 Expo 54 生成的无版本 AGP classpath 补全为显式版本，使 Honor `com.hihonor.mcs.asplugin` 可以正常工作；
- 已有显式 AGP 版本时保持不变，重复 prebuild 不会重复注入。

## 兼容性

- 通知图标处理只在宿主配置图标或已存在对应 FCM metadata 时生效；未配置图标的项目继续使用 DooPush fallback；
- Honor 逻辑只在启用 `honor` vendor 时生效，不影响 FCM、HMS、OPPO、VIVO、小米和魅族通道；
- AGP 版本从项目实际安装的 React Native version catalog 读取，不硬编码 Expo 54 的固定版本；
- 所有修改均保持 config plugin 幂等，可重复执行 `expo prebuild`。

## 测试

- [x] `cd sdk/react-native/DooPushSDK && pnpm test`：3 个 test suites、16 个 tests 全部通过；
- [x] `cd sdk/react-native/DooPushSDK && pnpm build`：TypeScript 与 config plugin 构建通过；
- [x] Expo SDK 54 项目执行 `expo prebuild --platform android --clean` 成功；
- [x] 生成的 `AndroidManifest.xml` 使用宿主 `@drawable/notification_icon` 并包含 `tools:replace="android:resource"`；
- [x] 生成的根级 `build.gradle` 包含显式 AGP classpath，Honor `app_id` / `developer_id` placeholders 正确生成；
- [x] Android arm64 Release APK 构建成功；
- [x] OPPO / HMS 厂商推送真机接收验证通过。
