### PR TITLE
fix(android): sync refreshed FCM tokens to server

### DIFF
--- a/api/cmd/serve.go
+++ b/api/cmd/serve.go
@@ -219,6 +219,7 @@ func startServer() {
 		apiKeyRoutes.Use(middleware.APIKeyAuth())
 		{
 			apiKeyRoutes.POST("/apps/:appId/devices", deviceCtrl.RegisterDevice)
+			apiKeyRoutes.PUT("/apps/:appId/devices/:deviceId/token", deviceCtrl.UpdateDeviceToken)
 			apiKeyRoutes.POST("/apps/:appId/push/statistics/report", pushCtrl.ReportPushStatistics)
 		}
 

--- a/api/go.mod
+++ b/api/go.mod
@@ -3,6 +3,7 @@ module github.com/doopush/doopush/api
 go 1.24.4
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/alicebob/miniredis/v2 v2.37.0
 	github.com/gin-gonic/gin v1.9.1
 	github.com/golang-jwt/jwt/v5 v5.2.0

--- a/api/go.sum
+++ b/api/go.sum
@@ -1,3 +1,5 @@
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
@@ -79,6 +81,7 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZXnvk=
 github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=

--- a/api/internal/controllers/device_controller.go
+++ b/api/internal/controllers/device_controller.go
@@ -41,6 +41,11 @@ type RegisterDeviceRequest struct {
 	Tags       []services.DeviceTagItem `json:"tags" example:"[{\"tag_name\":\"user_type\",\"tag_value\":\"vip\"},{\"tag_name\":\"version\",\"tag_value\":\"1.0\"}]"`
 }
 
+// UpdateDeviceTokenRequest 更新设备 Token 请求
+type UpdateDeviceTokenRequest struct {
+	Token string `json:"token" binding:"required" example:"new_device_token_here"`
+}
+
 // DeviceListResponse 设备列表响应
 type DeviceListResponse struct {
 	Devices []interface{} `json:"devices"`
@@ -108,6 +113,56 @@ func (d *DeviceController) RegisterDevice(c *gin.Context) {
 		Message: "设备注册成功",
 		Data:    device,
 	})
+}
+
+// UpdateDeviceToken 更新设备推送 Token
+// @Summary 更新设备推送 Token
+// @Description FCM/APNs 等推送服务轮换 Token 后，按设备 ID 更新原设备记录并保留标签、分组等关联
+// @Tags 设备管理
+// @Accept json
+// @Produce json
+// @Security ApiKeyAuth
+// @Param appId path int true "应用ID"
+// @Param deviceId path int true "设备ID"
+// @Param request body UpdateDeviceTokenRequest true "新Token"
+// @Success 200 {object} response.APIResponse
+// @Failure 400 {object} response.APIResponse
+// @Failure 401 {object} response.APIResponse
+// @Failure 404 {object} response.APIResponse
+// @Failure 422 {object} response.APIResponse
+// @Router /apps/{appId}/devices/{deviceId}/token [put]
+func (d *DeviceController) UpdateDeviceToken(c *gin.Context) {
+	appID, err := strconv.ParseUint(c.Param("appId"), 10, 32)
+	if err != nil {
+		response.BadRequest(c, "无效的应用ID")
+		return
+	}
+
+	deviceID, err := strconv.ParseUint(c.Param("deviceId"), 10, 32)
+	if err != nil {
+		response.BadRequest(c, "无效的设备ID")
+		return
+	}
+
+	var req UpdateDeviceTokenRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "请求参数错误: "+err.Error())
+		return
+	}
+
+	if err := d.deviceService.UpdateDeviceToken(uint(appID), uint(deviceID), req.Token); err != nil {
+		switch err {
+		case services.ErrDeviceNotFound:
+			response.NotFound(c, err.Error())
+		case services.ErrDeviceTokenConflict:
+			response.Error(c, http.StatusUnprocessableEntity, err.Error())
+		default:
+			response.InternalServerError(c, err.Error())
+		}
+		return
+	}
+
+	response.Success(c, nil)
 }
 
 // GetDevices 获取设备列表

--- a/api/internal/services/device_service.go
+++ b/api/internal/services/device_service.go
@@ -14,6 +14,11 @@ import (
 // DeviceService 设备服务
 type DeviceService struct{}
 
+var (
+	ErrDeviceNotFound      = errors.New("设备不存在")
+	ErrDeviceTokenConflict = errors.New("新Token已绑定到其他设备")
+)
+
 // NewDeviceService 创建设备服务
 func NewDeviceService() *DeviceService {
 	return &DeviceService{}
@@ -111,6 +116,41 @@ func (s *DeviceService) RegisterDevice(appID uint, token, bundleID, platform, ch
 	}
 
 	return device, nil
+}
+
+// UpdateDeviceToken 按设备主键更新推送 Token，保留设备的标签、分组和推送历史关联。
+func (s *DeviceService) UpdateDeviceToken(appID, deviceID uint, token string) error {
+	var device models.Device
+	if err := database.DB.Where("id = ? AND app_id = ?", deviceID, appID).First(&device).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrDeviceNotFound
+		}
+		return errors.New("查询设备失败")
+	}
+
+	tokenHash := utils.HashString(token)
+	var existing models.Device
+	if err := database.DB.Where(
+		"app_id = ? AND token_hash = ? AND id <> ?",
+		appID,
+		tokenHash,
+		deviceID,
+	).First(&existing).Error; err == nil {
+		return ErrDeviceTokenConflict
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return errors.New("检查设备Token失败")
+	}
+
+	updates := map[string]interface{}{
+		"token":      token,
+		"token_hash": tokenHash,
+		"last_seen":  utils.TimeNow(),
+	}
+	if err := database.DB.Model(&device).Updates(updates).Error; err != nil {
+		return errors.New("设备Token更新失败")
+	}
+
+	return nil
 }
 
 func normalizePushEnvironment(platform, pushEnv string) string {

--- a/api/internal/services/device_service_test.go
+++ b/api/internal/services/device_service_test.go
@@ -1,0 +1,54 @@
+package services
+
+import (
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/doopush/doopush/api/internal/database"
+	"github.com/doopush/doopush/api/pkg/utils"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+)
+
+func TestUpdateDeviceTokenUpdatesExistingDeviceRow(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("create sql mock: %v", err)
+	}
+	defer sqlDB.Close()
+
+	db, err := gorm.Open(mysql.New(mysql.Config{
+		Conn:                      sqlDB,
+		SkipInitializeWithVersion: true,
+	}), &gorm.Config{SkipDefaultTransaction: true})
+	if err != nil {
+		t.Fatalf("open gorm: %v", err)
+	}
+
+	previousDB := database.DB
+	database.DB = db
+	defer func() { database.DB = previousDB }()
+
+	now := time.Now()
+	mock.ExpectQuery(regexp.QuoteMeta(
+		"SELECT * FROM `devices` WHERE (id = ? AND app_id = ?) AND `devices`.`deleted_at` IS NULL ORDER BY `devices`.`id` LIMIT 1",
+	)).WithArgs(uint(42), uint(7)).WillReturnRows(sqlmock.NewRows([]string{
+		"id", "app_id", "token", "token_hash", "platform", "channel", "status", "created_at", "updated_at", "deleted_at",
+	}).AddRow(42, 7, "old-token", utils.HashString("old-token"), "android", "fcm", 1, now, now, nil))
+
+	mock.ExpectQuery("SELECT \\* FROM `devices` WHERE .*token_hash = \\?.*id <> \\?.*LIMIT 1").
+		WithArgs(uint(7), utils.HashString("new-token"), uint(42)).
+		WillReturnError(gorm.ErrRecordNotFound)
+
+	mock.ExpectExec("UPDATE `devices` SET .*`token`=\\?.*`token_hash`=\\?.* WHERE `devices`.`deleted_at` IS NULL AND `id` = \\?").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := NewDeviceService().UpdateDeviceToken(7, 42, "new-token"); err != nil {
+		t.Fatalf("update token: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}

--- a/docs/sdk/android-integration.md
+++ b/docs/sdk/android-integration.md
@@ -79,7 +79,7 @@ allprojects {
 ```kotlin
 dependencies {
     // DooPush SDK - JitPack
-    implementation 'com.github.doopush:doopush-android-sdk:1.2.2'
+    implementation 'com.github.doopush:doopush-android-sdk:1.2.3'
 
     // 必需：Firebase Cloud Messaging
     implementation platform('com.google.firebase:firebase-bom:32.7.0')

--- a/docs/sdk/index.md
+++ b/docs/sdk/index.md
@@ -7,8 +7,8 @@ DooPush 为移动应用提供完整的跨平台推送解决方案，支持 iOS�
 | 平台 | 状态 | SDK 版本 | 说明 |
 |------|------|----------|------|
 | **iOS** | ✅ 已支持 | v1.3.0 | 原生 APNs 集成，生产可用 |
-| **Android** | ✅ 已支持 | v1.2.2 | 多厂商推送支持，生产可用 |
-| **React Native** | ✅ 已支持 | v0.5.2 | 基于 Expo Modules 的 RN/Expo 接入层，支持 APNs、FCM 与 6 类 Android OEM 通道，生产可用 |
+| **Android** | ✅ 已支持 | v1.2.3 | 多厂商推送支持，生产可用 |
+| **React Native** | ✅ 已支持 | v0.5.3 | 基于 Expo Modules 的 RN/Expo 接入层，支持 APNs、FCM 与 6 类 Android OEM 通道，生产可用 |
 
 ## 📖 iOS SDK 文档
 

--- a/sdk/android/DooPushSDK/README.md
+++ b/sdk/android/DooPushSDK/README.md
@@ -308,6 +308,10 @@ A: SDK 提供了详细的日志输出，使用 `adb logcat -s DooPushManager` �
 
 ## 更新日志
 
+### v1.2.3
+- **Fix (FCM)**：FCM token 刷新后立即重新上报当前设备，避免本地已切换到新 token、服务端仍持有旧 token 而永久断推。
+- `BuildConfig.SDK_VERSION` / `DooPushDevice.SDK_VERSION` → `1.2.3`。
+
 ### v1.2.2
 - **Fix (OPPO)**：OPPO/HeyTap 厂商注册失败时只抛通用超时错误，无法定位根因；`onError` 改为透出 MCS 返回的真实错误信息（`getFullDescription()`），便于排查静默失败。
 - `BuildConfig.SDK_VERSION` / `DooPushDevice.SDK_VERSION` → `1.2.2`。

--- a/sdk/android/DooPushSDK/README.md
+++ b/sdk/android/DooPushSDK/README.md
@@ -309,7 +309,7 @@ A: SDK 提供了详细的日志输出，使用 `adb logcat -s DooPushManager` �
 ## 更新日志
 
 ### v1.2.3
-- **Fix (FCM)**：FCM token 刷新后立即重新上报当前设备，避免本地已切换到新 token、服务端仍持有旧 token 而永久断推。
+- **Fix (FCM)**：FCM token 刷新后按服务端 device ID 更新原设备记录，避免创建重复设备，并保留已有标签、分组和推送历史关联。
 - `BuildConfig.SDK_VERSION` / `DooPushDevice.SDK_VERSION` → `1.2.3`。
 
 ### v1.2.2

--- a/sdk/android/DooPushSDK/lib/build.gradle
+++ b/sdk/android/DooPushSDK/lib/build.gradle
@@ -88,6 +88,7 @@ dependencies {
     testImplementation 'org.mockito.kotlin:mockito-kotlin:5.2.1'
     testImplementation 'org.robolectric:robolectric:4.11.1'
     testImplementation 'androidx.test:core:1.5.0'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
     
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/sdk/android/DooPushSDK/lib/build.gradle
+++ b/sdk/android/DooPushSDK/lib/build.gradle
@@ -16,7 +16,7 @@ android {
         consumerProguardFiles "consumer-rules.pro"
 
         // 版本信息
-        buildConfigField "String", "SDK_VERSION", "\"1.2.2\""
+        buildConfigField "String", "SDK_VERSION", "\"1.2.3\""
         buildConfigField "String", "BUILD_TIME", "\"${new Date().format('yyyy-MM-dd HH:mm:ss')}\""
     }
 
@@ -102,7 +102,7 @@ afterEvaluate {
                 
                 groupId = 'com.doopush'
                 artifactId = 'android-sdk'
-                version = '1.2.2'
+                version = '1.2.3'
 
                 pom {
                     name = 'DooPush Android SDK'

--- a/sdk/android/DooPushSDK/lib/src/main/java/com/doopush/sdk/DooPushDevice.kt
+++ b/sdk/android/DooPushSDK/lib/src/main/java/com/doopush/sdk/DooPushDevice.kt
@@ -19,7 +19,7 @@ class DooPushDevice(private val context: Context) {
         /**
          * SDK版本号
          */
-        const val SDK_VERSION = "1.2.2"
+        const val SDK_VERSION = "1.2.3"
         
         /**
          * 用户代理格式模板
@@ -151,7 +151,7 @@ class DooPushDevice(private val context: Context) {
     
     /**
      * 生成用户代理字符串
-     * 格式: DooPush-Android-SDK/1.2.2 (com.example.app; Google Pixel 7; Android 14)
+     * 格式: DooPush-Android-SDK/1.2.3 (com.example.app; Google Pixel 7; Android 14)
      * 
      * @return 用户代理字符串
      */

--- a/sdk/android/DooPushSDK/lib/src/main/java/com/doopush/sdk/DooPushManager.kt
+++ b/sdk/android/DooPushSDK/lib/src/main/java/com/doopush/sdk/DooPushManager.kt
@@ -1298,14 +1298,31 @@ class DooPushManager private constructor() {
         
         // FCM refreshes its token independently of app activation. Persisting
         // only the local value leaves the DooPush server pointing at the stale
-        // token, so immediately re-register the current device information.
+        // token, so update the existing server-side device by its stable ID.
         if (isConfigured.get() && !oldToken.isNullOrEmpty() && oldToken != newToken) {
             Log.d(TAG, "Token已变化，更新服务器")
-            updateDeviceInfo { success, error ->
-                if (success) {
-                    Log.i(TAG, "Token刷新后服务端同步成功")
-                } else {
-                    Log.e(TAG, "Token刷新后服务端同步失败: ${error?.message ?: "unknown error"}")
+            if (!deviceId.isNullOrEmpty()) {
+                networking?.updateDeviceToken(
+                    deviceId,
+                    newToken,
+                    object : DooPushNetworking.UpdateTokenCallback {
+                        override fun onSuccess() {
+                            Log.i(TAG, "Token刷新后服务端同步成功")
+                        }
+
+                        override fun onError(error: DooPushError) {
+                            Log.e(TAG, "Token刷新后服务端同步失败: ${error.message}")
+                        }
+                    }
+                )
+            } else {
+                // 旧版缓存可能只保存了 token；没有服务端设备 ID 时才回退到注册。
+                updateDeviceInfo { success, error ->
+                    if (success) {
+                        Log.i(TAG, "Token刷新后服务端注册成功")
+                    } else {
+                        Log.e(TAG, "Token刷新后服务端注册失败: ${error?.message ?: "unknown error"}")
+                    }
                 }
             }
         }

--- a/sdk/android/DooPushSDK/lib/src/main/java/com/doopush/sdk/DooPushManager.kt
+++ b/sdk/android/DooPushSDK/lib/src/main/java/com/doopush/sdk/DooPushManager.kt
@@ -1296,10 +1296,18 @@ class DooPushManager private constructor() {
             persistRegistration(newToken, deviceId, vendor)
         }
         
-        // 如果已配置且有旧token，更新服务器
+        // FCM refreshes its token independently of app activation. Persisting
+        // only the local value leaves the DooPush server pointing at the stale
+        // token, so immediately re-register the current device information.
         if (isConfigured.get() && !oldToken.isNullOrEmpty() && oldToken != newToken) {
             Log.d(TAG, "Token已变化，更新服务器")
-            // 这里可以实现token更新逻辑，暂时省略
+            updateDeviceInfo { success, error ->
+                if (success) {
+                    Log.i(TAG, "Token刷新后服务端同步成功")
+                } else {
+                    Log.e(TAG, "Token刷新后服务端同步失败: ${error?.message ?: "unknown error"}")
+                }
+            }
         }
     }
 

--- a/sdk/android/DooPushSDK/lib/src/main/java/com/doopush/sdk/DooPushNetworking.kt
+++ b/sdk/android/DooPushSDK/lib/src/main/java/com/doopush/sdk/DooPushNetworking.kt
@@ -58,7 +58,7 @@ class DooPushNetworking(private val config: DooPushConfig) {
             val authenticatedRequest = originalRequest.newBuilder()
                 .header("X-API-Key", config.apiKey)
                 .header("Content-Type", "application/json")
-                .header("User-Agent", "DooPush-Android-SDK/1.2.2")
+                .header("User-Agent", "DooPush-Android-SDK/1.2.3")
                 .build()
             chain.proceed(authenticatedRequest)
         }

--- a/sdk/android/DooPushSDK/lib/src/test/java/com/doopush/sdk/DooPushTokenRefreshTest.kt
+++ b/sdk/android/DooPushSDK/lib/src/test/java/com/doopush/sdk/DooPushTokenRefreshTest.kt
@@ -1,0 +1,75 @@
+package com.doopush.sdk
+
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import java.util.concurrent.TimeUnit
+
+@RunWith(RobolectricTestRunner::class)
+class DooPushTokenRefreshTest {
+
+    @Test
+    fun refreshedFcmTokenUpdatesExistingDeviceById() {
+        val server = MockWebServer()
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{\"code\":200,\"message\":\"成功\"}"))
+        server.start()
+
+        try {
+            val manager = DooPushManager.getInstance()
+            manager.configure(
+                RuntimeEnvironment.getApplication(),
+                appId = "test-app",
+                apiKey = "test_api_key_1234",
+                baseURL = server.url("/api/v1").toString()
+            )
+
+            setPrivateField(manager, "cachedToken", "old-token")
+            setPrivateField(manager, "cachedDeviceId", "42")
+            invokePrivate(
+                manager,
+                "persistRegistration",
+                arrayOf<Class<*>>(String::class.java, String::class.java, String::class.java),
+                arrayOf<Any>("old-token", "42", "fcm")
+            )
+
+            invokePrivate(
+                manager,
+                "handleTokenRefresh",
+                arrayOf<Class<*>>(String::class.java),
+                arrayOf<Any>("new-token")
+            )
+
+            val request = server.takeRequest(5, TimeUnit.SECONDS)
+                ?: error("Token refresh request was not sent")
+            assertEquals("PUT", request.method)
+            assertEquals("/api/v1/apps/test-app/devices/42/token", request.path)
+            assertTrue(request.body.readUtf8().contains("\"token\":\"new-token\""))
+        } finally {
+            server.shutdown()
+        }
+    }
+
+    private fun setPrivateField(target: Any, name: String, value: Any?) {
+        target.javaClass.getDeclaredField(name).apply {
+            isAccessible = true
+            set(target, value)
+        }
+    }
+
+    private fun invokePrivate(
+        target: Any,
+        name: String,
+        parameterTypes: Array<Class<*>>,
+        args: Array<Any>
+    ) {
+        target.javaClass.getDeclaredMethod(name, *parameterTypes).apply {
+            isAccessible = true
+            invoke(target, *args)
+        }
+    }
+}

--- a/sdk/react-native/DooPushSDK/README.md
+++ b/sdk/react-native/DooPushSDK/README.md
@@ -182,7 +182,7 @@ MIT
 ## CHANGELOG
 
 ### v0.5.3
-- **Fix (Android/FCM)**：依赖 Android SDK v1.2.3，FCM token 刷新后会立即同步到 DooPush 服务端，避免服务端继续使用旧 token。
+- **Fix (Android/FCM)**：依赖 Android SDK v1.2.3，FCM token 刷新后会按 device ID 更新服务端原设备记录，避免旧 token 断推或产生重复设备。
 - **Fix (Android dependency)**：React Native bridge 的原生依赖由遗留的 `1.2.0` 对齐到 `1.2.3`，确保 v1.2.1-v1.2.3 的原生修复实际进入应用构建。
 
 ### v0.5.2

--- a/sdk/react-native/DooPushSDK/README.md
+++ b/sdk/react-native/DooPushSDK/README.md
@@ -181,6 +181,10 @@ MIT
 
 ## CHANGELOG
 
+### v0.5.3
+- **Fix (Android/FCM)**：依赖 Android SDK v1.2.3，FCM token 刷新后会立即同步到 DooPush 服务端，避免服务端继续使用旧 token。
+- **Fix (Android dependency)**：React Native bridge 的原生依赖由遗留的 `1.2.0` 对齐到 `1.2.3`，确保 v1.2.1-v1.2.3 的原生修复实际进入应用构建。
+
 ### v0.5.2
 - **Fix (config plugin)**：OPPO 注册静默超时（拿不到 RegisterId），因为构建产物缺少 HeyTap MCS 所需的 manifest 声明；新增 `withDooPushOppoManifest`，启用 `oppo` 厂商时注入两条 `RECIEVE_MCS_MESSAGE` 权限与 `CompatibleDataMessageCallbackService` / `DataMessageCallbackService` 回调服务。
 - **Fix (Android)**：注册失败事件（`onRegisterError` / `register` reject）透出厂商返回的真实错误信息，替换此前的通用 "register failed"。

--- a/sdk/react-native/DooPushSDK/android/build.gradle
+++ b/sdk/react-native/DooPushSDK/android/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 group = 'com.doopush.reactnative'
-version = '0.5.0'
+version = '0.5.3'
 
 def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")
 apply from: expoModulesCorePlugin
@@ -18,7 +18,7 @@ android {
         minSdkVersion safeExtGet("minSdkVersion", 26)
         targetSdkVersion safeExtGet("targetSdkVersion", 34)
         versionCode 1
-        versionName "0.5.0"
+        versionName "0.5.3"
     }
 
     compileOptions {
@@ -44,7 +44,7 @@ dependencies {
     // DooPush native Android SDK v1.2.0+
     // During v0.1 alpha dev: rely on mavenLocal (./gradlew :lib:publishToMavenLocal in sdk/android/DooPushSDK).
     // Once published, this resolves from JitPack via the maven{} block above.
-    implementation 'com.doopush:android-sdk:1.2.0'
+    implementation 'com.doopush:android-sdk:1.2.3'
 
     // FCM (transitive via DooPush AAR's runtime deps for FCM, but explicit here for clarity).
     implementation platform('com.google.firebase:firebase-bom:32.7.0')

--- a/sdk/react-native/DooPushSDK/package.json
+++ b/sdk/react-native/DooPushSDK/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doopush-react-native-sdk",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "React Native SDK for DooPush push notification service. Built with Expo Modules API; works in Expo (managed/prebuild) and bare RN.",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
## Summary

- update the existing server-side device record by stable `deviceId` when FCM rotates its token
- add the authenticated `PUT /apps/:appId/devices/:deviceId/token` API endpoint
- preserve device tags, groups, history, and identity instead of creating a duplicate device
- bump the Android SDK to `1.2.3`
- align the React Native SDK native dependency with Android SDK `1.2.3` and bump the RN package to `0.5.3`
- sync the SDK version references in `docs/`

## Problem

The Android SDK previously persisted a refreshed FCM token only in local storage. The DooPush server continued to hold the old token, so push delivery could stop after token rotation.

The first implementation attempted to call the registration endpoint with the new token. Because the API identifies existing devices by token hash, that would create a second device record and leave tags/groups attached to the stale-token record. This PR now updates the original row by its stable server device ID.

The React Native bridge also still declared `com.doopush:android-sdk:1.2.0`, which meant later native fixes were not included in consumer builds.

## Implementation

- Android caches the server-returned device ID after registration.
- On FCM token rotation, it calls `PUT /apps/:appId/devices/:deviceId/token` with the new token.
- The API verifies that the device belongs to the app, rejects token collisions, and updates `token`, `token_hash`, and `last_seen` on the same row.
- If an older installation has a token but no cached device ID, the SDK falls back to device registration.

## Verification

- `cd api && go test ./...`
- added a SQL-mock regression test proving the existing device row is updated by ID
- added an Android MockWebServer test asserting token refresh sends `PUT /apps/test-app/devices/42/token`
- `git diff --check`
- Android Gradle test execution is currently blocked on this machine because no Android SDK path is installed; the test and dependency are committed for CI/Android environments

## Compatibility

- no public SDK API changes
- existing cached registrations remain valid
- tags, groups, push logs, and other relations remain attached to the original device ID
- server synchronization runs only when FCM reports a token different from the cached token
